### PR TITLE
Add the Slice package and article

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ TL;DR? See an overview of examples using JavaScript Proxy in [the summary](./exa
 - [Use ES6 Proxies](https://egghead.io/lessons/javascript-use-es6-proxies) by Kent C. Dodds
 
 ### Articles
+
+- [Recreating Python's Slice Syntax in JavaScript Using ES6 Proxies](https://intoli.com/blog/python-slicing-in-javascript/) by Evan Sangaline
 - [Metaprogramming in ES6: Part 3 - Proxies](https://www.keithcirkel.co.uk/metaprogramming-in-es6-part-3-proxies/) by Keith Cirkel
 - [Exploring JS chapter 28. Metaprogramming with proxies](http://exploringjs.com/es6/ch_proxies.html) by Dr. Axel Rauschmayer
 - [ES6 Proxies in Depth](https://ponyfoo.com/articles/es6-proxies-in-depth) by Nicolás Bevacqua

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ TL;DR? See an overview of examples using JavaScript Proxy in [the summary](./exa
 
 ### Modules
 
+- [slice](https://github.com/intoli/slice): Slice implements Python's extended slice syntax and negative indexing in JavaScript using proxies.
 - [zer](https://github.com/jbmusso/zer): Zer helps you serialize any JavaScript chains to String representations of any languages by leveraging ES2015 `Proxy` objects
 - [negative-array](https://github.com/sindresorhus/negative-array): Negative array index support `array[-1]` using ES2015 Proxy
 - [tpyo](https://github.com/mathiasbynens/tpyo): A small script that enables you to make typos in JavaScript property names. Powered by ES6 proxies + Levenshtein string distance.


### PR DESCRIPTION
This adds a link to the [Slice](https://github.com/intoli/slice) package which implements Python's extended slice syntax and negative indexing in JavaScript using proxies. It also links to the [Recreating Python's Slice Syntax in JavaScript Using ES6 Proxies](https://intoli.com/blog/python-slicing-in-javascript/) article which uses the process of writing Slice as a vehicle for explaining how proxies work in great detail.